### PR TITLE
quick fix: custom timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 #docs/
 .idea/workspace.xml
 **/.idea/workspace.xml
+/release/
 
 ### Plasma 5 .directory files
 **/.directory*

--- a/docs/assets/phase_src/phase.js
+++ b/docs/assets/phase_src/phase.js
@@ -304,7 +304,7 @@ function customTimer() {
         let seconds = 0;
         let digits = inputTime.value.toString().split(' ');
         digits[0] ? days = parseInt(digits[0]) : days = 0;
-        digits[1] ? hours = digits[1] * boxMod : hours = 0;
+        digits[1] ? hours = parseInt(digits[1]) : hours = 0;
         digits[2] ? minutes = parseInt(digits[2]) : minutes = 0;
         digits[3] ? seconds = parseInt(digits[3]) : seconds = 0;
         let yearNow = planted.getFullYear();


### PR DESCRIPTION
Custom timers were, unintentionally, affected by the selected box's timer modifier. That meant that if you had a box that took more or less time to grow mushrooms, your custom timer was inaccurate. This fix removes the code applying the modifier.